### PR TITLE
feat: allow for setting the ecs-pipeline image repo via parameters

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
             role: worker
           containers:
           - name: ecs-pipeline
-            image: ${env.AwsAccount}.dkr.ecr.${env.AwsRegion}.amazonaws.com/ecs-pipeline
+            image: ${env.EcsPipelineRepository}
             imagePullPolicy: Always
             command:
             - cat


### PR DESCRIPTION
Allow for setting the `ecs-pipeline` repo url via parameters

Necessitated by the switch from quay.io -> ecr -> gcr